### PR TITLE
The Serializer closes itself on 'stop'.

### DIFF
--- a/Export data to files with Suitcase.ipynb
+++ b/Export data to files with Suitcase.ipynb
@@ -189,8 +189,6 @@
     "    def cb(name, doc):\n",
     "        filler(name, doc)  # Fill in place any externally-stored data written by area detector.\n",
     "        serializer(name, doc)\n",
-    "        if name == 'stop':\n",
-    "            serializer.close()\n",
     "\n",
     "    return [cb], []\n",
     "\n",


### PR DESCRIPTION
This simplification made possible by https://github.com/bluesky/suitcase-tiff/pull/28

This should not be merged until the next suitcase-tiff release (> 0.1.3) comes out.