### PR TITLE
Use JupyterLab 1.0 and a tagged version of bluesky.

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -5,7 +5,7 @@ databroker >=0.13.2
 distributed
 ipympl
 ipywidgets
-jupyterlab
+jupyterlab >=1.0
 lmfit
 matplotlib
 ophyd

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/bluesky/bluesky  # use the latest fixes for storing metadata
+bluesky >=1.6.0rc2
 git+https://github.com/caproto/caproto@ophyd-tutorial  # TEMP BRANCH
 dask
 databroker >=0.13.2


### PR DESCRIPTION
Now that we have an RC, it will be more stable to use that instead of building off of `master`. Also, use JupyterLab 1.x.

The currently-deployed image has broken plotting. The JavaScript console shows:
![image](https://user-images.githubusercontent.com/2279598/67034424-a3ee6f00-f0e5-11e9-8757-fa994b74e91f.png)

This branch, which you can try [at this binder link](https://mybinder.org/v2/gh/danielballan/tutorial/use-tagged-bluesky?urlpath=lab) now has working plotting and no errors in the console. Screenshot:

![image](https://user-images.githubusercontent.com/2279598/67036190-27f62600-f0e9-11e9-9170-faac11e8c737.png)

Thanks @ambarb for alerting us to the broken plotting.